### PR TITLE
feat: update sec section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ the different components of your project. Some example resources are:
     Practices](https://bestpractices.coreinfrastructure.org/en).
     * [OWASP Top 10 Web Application Security Risks](https://owasp.org/www-project-top-ten/).
 * Don’t blindly trust out-of-the-box software and default
-configurations, e.g. popular Docker images, aws services, etc. 
+configurations, e.g. open source libraries, Docker images, aws services, etc.
 Malicious software can be present and default configurations usually
 have simplicity as the primary goal, not security.
 * Incorporate security in the entire Software Development Lifecycle:

--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ Malicious software can be present and default configurations usually
 have simplicity as the primary goal, not security.
 * Incorporate security in the entire Software Development Lifecycle:
     * Include security considerations when gathering requirements.
-    * Threat model when designing.
+    * Threat model continuously.
     * Implement tests and build processes that evaluate security.
   
     Some examples:
+    * Ask [the four key threat model questions](https://www.threatmodelingmanifesto.org/) during backlog refinement.
     * During the design phase:
         * Explicitly map out attack surfaces.
 	        * Discuss what security means for your project - you may

--- a/README.md
+++ b/README.md
@@ -90,18 +90,8 @@ have simplicity as the primary goal, not security.
     * Implement tests and build processes that evaluate security.
   
     Some examples:
-    * Ask [the four key threat model questions](https://www.threatmodelingmanifesto.org/) during backlog refinement.
-    * During the design phase:
-        * Explicitly map out attack surfaces.
-	        * Discuss what security means for your project - you may
-	        have different parts where different aspects are
-	        important (e.g. an information site where the main risk
-	        is lack of availability or integrity and a user part
-	        where confidentiality is the major concern).
-        * Discuss risks and consequences (using a risk analysis
-        framework may be beneficial).
-	        * Do not forget to document - identified risks, risk
-	        mitigations and accepted risks may need to be revisited.
+    * Ask [the four key threat model questions](https://www.threatmodelingmanifesto.org/)
+    during backlog refinement.
     * Enable services like [Dependabot](https://dependabot.com/) or
     [Snyk](https://snyk.io/) to enable alerts for dependices for your
     project (this can easily be done at GitHub).

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ the different components of your project. Some example resources are:
     * [Linux Foundation (LF) Core Infrastructure Initiative (CII) Best
     Practices](https://bestpractices.coreinfrastructure.org/en).
     * [OWASP Top 10 Web Application Security Risks](https://owasp.org/www-project-top-ten/).
+    * [OWASP Slack](https://owasp.org/slack/invite)
 * Don’t blindly trust out-of-the-box software and default
 configurations, e.g. open source libraries, Docker images, aws services, etc.
 Malicious software can be present and default configurations usually


### PR DESCRIPTION
Added links to threat model manifesto and the OWASP Slack channel. Also refined some other parts of the security text to make it more relevant and easier to read.